### PR TITLE
CashFlow constructor period override

### DIFF
--- a/lib/xirr/base.rb
+++ b/lib/xirr/base.rb
@@ -16,7 +16,7 @@ module Xirr
     # @return [Rational]
     # @param date [Date]
     def t_in_days(date)
-      (date - cf.min_date) / Xirr::DAYS_IN_YEAR
+      (date - cf.min_date) / cf.period
     end
 
     # Net Present Value function that will be used to reduce the cashflow

--- a/lib/xirr/cashflow.rb
+++ b/lib/xirr/cashflow.rb
@@ -3,6 +3,7 @@ module Xirr
   # Expands [Array] to store a set of transactions which will be used to calculate the XIRR
   # @note A Cashflow should consist of at least two transactions, one positive and one negative.
   class Cashflow < Array
+    attr_reader :period
 
     # @param args [Transaction]
     # @example Creating a Cashflow
@@ -11,8 +12,9 @@ module Xirr
     #   cf << Transaction.new(-1234, date: '2013-03-31'.to_date)
     #   Or
     #   cf = Cashflow.new Transaction.new( 1000, date: '2013-01-01'.to_date), Transaction.new(-1234, date: '2013-03-31'.to_date)
-    def initialize(compacted = false, *args)
+    def initialize(period = Xirr::DAYS_IN_YEAR, compacted = false, *args)
       @compacted = compacted
+      @period = period
       args.each { |a| self << a }
       self.flatten!
     end
@@ -75,7 +77,7 @@ module Xirr
       compact = Hash.new
       uniq_dates.each { |date| compact[date] = 0 }
       self.each { |flow| compact[flow.date] += flow.amount }
-      Cashflow.new(true, compact.map { |key, value| Transaction.new(value, date: key.to_date) })
+      Cashflow.new(Xirr::DAYS_IN_YEAR, true, compact.map { |key, value| Transaction.new(value, date: key.to_date) })
     end
 
     # Calls XIRR but throws no exception and returns with 0

--- a/lib/xirr/version.rb
+++ b/lib/xirr/version.rb
@@ -1,4 +1,4 @@
 module Xirr
   # Version of the Gem
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/test/test_cashflow.rb
+++ b/test/test_cashflow.rb
@@ -193,7 +193,7 @@ describe 'Cashflows' do
 
   describe 'of a long investment' do
     before(:all) do
-      @cf = Cashflow.new false, Transaction.new(-1000, date: Date.new(1957, 1, 1)), Transaction.new(390000, date: Date.new(2013, 1, 1))
+      @cf = Cashflow.new Xirr::DAYS_IN_YEAR, false, Transaction.new(-1000, date: Date.new(1957, 1, 1)), Transaction.new(390000, date: Date.new(2013, 1, 1))
     end
 
     it 'has an Internal Rate of Return on Bisection Method' do
@@ -282,14 +282,19 @@ describe 'Cashflows' do
     end
 
     it 'has zero for years of investment' do
-      cf = Cashflow.new false, Transaction.new(105187.06, date: '2011-12-07'.to_date), Transaction.new(-105187.06 * 1.0697668105671994, date: '2011-12-07'.to_date)
+      cf = Cashflow.new Xirr::DAYS_IN_YEAR, false, Transaction.new(105187.06, date: '2011-12-07'.to_date), Transaction.new(-105187.06 * 1.0697668105671994, date: '2011-12-07'.to_date)
       assert_equal 0.0, cf.irr_guess
       assert_equal Xirr.config.replace_for_nil, cf.xirr(nil, :newton_method)
     end
 
     it 'has is valid even if compacted' do
-      cf = Cashflow.new false, Transaction.new(100, date: Date.today), Transaction.new(-100, date: Date.today)
+      cf = Cashflow.new Xirr::DAYS_IN_YEAR, false, Transaction.new(100, date: Date.today), Transaction.new(-100, date: Date.today)
       assert_equal 0.0, cf.xirr(nil, :newton_method, true)
+    end
+
+    it 'respects a different period' do
+      cf = Cashflow.new 100, false, Transaction.new(-1000, date: Date.new(1957, 1, 1)), Transaction.new(390000, date: Date.new(2013, 1, 1))
+      assert_equal 0.029598, cf.xirr
     end
 
   end


### PR DESCRIPTION
Hi @tubedude ,  I needed to be able to adjust the period so I modified Cashflow and Base to fit.  What do you think?

1.  Prepends new period argument with DAYS_IN_YEAR default to Cashflow initialize.
2.  Adds verifying unit test.
3.  Version bump due to the potentially breaking change.