### PR TITLE
Include patch versions for activesupport 5.2

### DIFF
--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10'
 
   spec.required_ruby_version = '>=2.2.2'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 5.2'
+  spec.add_dependency 'activesupport', '>= 4.2', '<5.3'
   spec.add_dependency 'RubyInline', '~> 3'
   spec.add_development_dependency 'minitest', '~> 5.4'
   spec.add_development_dependency 'coveralls', '~> 0'


### PR DESCRIPTION
Currently the gem does not support activesupport 5.2.1, the change fixes that. I don't think it should be limiting patch versions of activesupport, but minor versions does make sense.