### PR TITLE
Lowered activesupport required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Xirr
 [![Build Status](https://travis-ci.org/tubedude/xirr.svg)](https://travis-ci.org/tubedude/xirr)[![Coverage Status](https://coveralls.io/repos/tubedude/xirr/badge.svg?branch=master)](https://coveralls.io/r/tubedude/xirr?branch=master)[![Code Climate](https://codeclimate.com/github/tubedude/xirr/badges/gpa.svg)](https://codeclimate.com/github/tubedude/xirr)[![Ebert](https://ebertapp.io/github/tubedude/xirr.svg)](https://ebertapp.io/github/tubedude/xirr)
 
-
 This is a gem to calculate XIRR on Bisection Method or Newton Method.
 
 ## Installation
@@ -20,24 +19,24 @@ Or install it yourself as:
 
 ## Usage
 
-
-    include Xirr
+```rb
+include Xirr
     
-    cf = Cashflow.new
-    cf << Transaction.new(-1000,  date: '2014-01-01'.to_date)
-    cf << Transaction.new(-2000,  date: '2014-03-01'.to_date)
-    cf << Transaction.new( 4500, date: '2015-12-01'.to_date)
-    cf.xirr
-    # 0.25159694345042327 # [BigDecimal]
+cf = Xirr::Cashflow.new
+cf << Xirr::Transaction.new(-1000,  date: '2014-01-01'.to_date)
+cf << Xirr::Transaction.new(-2000,  date: '2014-03-01'.to_date)
+cf << Xirr::Transaction.new( 4500, date: '2015-12-01'.to_date)
+cf.xirr
+# 0.25159694345042327 # [BigDecimal]
 
-    flow = []
-    flow << Transaction.new(-1000,  date: '2014-01-01'.to_date)
-    flow << Transaction.new(-2000,  date: '2014-03-01'.to_date)
-    flow << Transaction.new( 4500, date: '2015-12-01'.to_date)
+flow = []
+flow << Xirr::Transaction.new(-1000,  date: '2014-01-01'.to_date)
+flow << Xirr::Transaction.new(-2000,  date: '2014-03-01'.to_date)
+flow << Xirr::Transaction.new( 4500, date: '2015-12-01'.to_date)
 
-    cf = Cashflow.new flow: flow
-    cf.xirr
-
+cf = Xirr::Cashflow.new(flow: flow)
+cf.xirr
+```    
 
 ## Configuration
 
@@ -73,6 +72,7 @@ https://github.com/wkranec/finance
 
 1. Fork it ( https://github.com/tubedude/xirr/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+3. Run specs (`rake default`)
+4. Commit your changes (`git commit -am 'Add some feature'`)
+5. Push to the branch (`git push origin my-new-feature`)
+6. Create a new Pull Request

--- a/lib/xirr.rb
+++ b/lib/xirr.rb
@@ -10,8 +10,6 @@ require 'xirr/newton_method'
 # @abstract adds a {Xirr::Cashflow} and {Xirr::Transaction} classes to calculate IRR of irregular transactions.
 # Calculates Xirr
 module Xirr
-
   autoload :Transaction, 'xirr/transaction'
   autoload :Cashflow, 'xirr/cashflow'
-
 end

--- a/test/test_cashflow.rb
+++ b/test/test_cashflow.rb
@@ -1,7 +1,6 @@
 require_relative 'test_helper'
 
 describe 'Cashflows' do
-
   describe 'of an ok investment' do
     before(:all) do
       @cf = Cashflow.new
@@ -38,7 +37,6 @@ describe 'Cashflows' do
       assert_equal '0.208'.to_f, @cf.irr_guess
     end
   end
-
 
   describe 'of an inverted ok investment' do
     before(:all) do
@@ -139,7 +137,6 @@ describe 'Cashflows' do
       assert_equal BigDecimal.new(0, 6), @cf.xirr
     end
 
-
     it 'with a wrong method is invalid' do
       assert_raises(ArgumentError) { @cf.xirr raise_exception: true, method: :no_method }
     end
@@ -151,7 +148,6 @@ describe 'Cashflows' do
     it 'raises error when xirr is called' do
       assert true, !@cf.irr_guess
     end
-
   end
 
   describe 'an all-positive Cashflow' do
@@ -194,7 +190,6 @@ describe 'Cashflows' do
     it 'has an educated guess' do
       assert_equal -0.022, @cf.irr_guess
     end
-
   end
 
   describe 'of a long investment' do
@@ -213,7 +208,6 @@ describe 'Cashflows' do
     it 'has an educated guess' do
       assert_equal 0.112, @cf.irr_guess.round(6)
     end
-
   end
 
   describe 'reapeated cashflow' do
@@ -232,7 +226,6 @@ describe 'Cashflows' do
     it 'sums all transactions' do
       assert_equal -3000.0, @cf.compact_cf.map(&:amount).inject(&:+)
     end
-
   end
 
   describe 'of a real case' do
@@ -278,7 +271,6 @@ describe 'Cashflows' do
     it 'is a long and bad investment and newton generates an error' do
       assert_equal '-1.0'.to_f, @cf.xirr #(method: :newton_method)
     end
-
   end
 
   describe 'xichen27' do
@@ -290,8 +282,8 @@ describe 'Cashflows' do
       assert_equal '-0.996814607'.to_f.round(3), cf.xirr.to_f.round(3)
     end
   end
-  describe 'marano' do
 
+  describe 'marano' do
     it 'it matchs Excel' do
       cf = Cashflow.new
       cf << Transaction.new(900.0, date: '2014-11-07'.to_date)
@@ -301,7 +293,6 @@ describe 'Cashflows' do
   end
 
   describe 'period' do
-
     it 'has zero for years of investment' do
       cf = Cashflow.new flow: [Transaction.new(105187.06, date: '2011-12-07'.to_date), Transaction.new(-105187.06 * 1.0697668105671994, date: '2011-12-07'.to_date)]
       assert_equal 0.0, cf.irr_guess
@@ -317,7 +308,5 @@ describe 'Cashflows' do
       cf = Cashflow.new period: 100, flow: [Transaction.new(-1000, date: Date.new(1957, 1, 1)), Transaction.new(390000, date: Date.new(2013, 1, 1))]
       assert_equal 0.112339, cf.xirr(period: 365.0)
     end
-
   end
-
 end

--- a/test/test_transactions.rb
+++ b/test/test_transactions.rb
@@ -4,14 +4,16 @@ describe 'Transaction' do
   before(:all) do
     @t = Transaction.new(1000, date: Date.today)
   end
+
   it 'converts amount to float' do
     assert true, @t.amount.kind_of?(Float)
   end
+
   it 'retreives the date' do
     assert_equal Date.today, @t.date
   end
+
   it 'has inspect' do
     assert_equal "T(1000.0,#{Date.today})", @t.inspect
   end
-
 end

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -18,13 +18,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>=2.2.2'
+
+  spec.add_dependency 'activesupport', '>= 4.1', '<= 5.3'
+  spec.add_dependency 'RubyInline', '~> 3'
+
+  spec.add_development_dependency 'activesupport', '~> 4.1.0'
+  spec.add_development_dependency 'minitest', '~> 5.11'
+  spec.add_development_dependency 'coveralls', '~> 0'
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10'
-
-  spec.required_ruby_version = '>=2.2.2'
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 5.3'
-  spec.add_dependency 'RubyInline', '~> 3'
-  spec.add_development_dependency 'minitest', '~> 5.4'
-  spec.add_development_dependency 'coveralls', '~> 0'
-
 end


### PR DESCRIPTION
Hi!

I am trying to get a XIRR function running in a Rails v4.1.16 app and the requirement for activesupport to be 4.2 is getting in the way. Specs pass just fine on 4.1 so let's lower it.

Also added some newlines for better styling in tests.