### PR TITLE
Allowing higher version of activesupport

### DIFF
--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>=2.2.2'
 
-  spec.add_dependency 'activesupport', '>= 4.1', '<= 5.3'
+  spec.add_dependency 'activesupport', '>= 4.1'
   spec.add_dependency 'RubyInline', '~> 3'
 
-  spec.add_development_dependency 'activesupport', '~> 4.1.0'
+  spec.add_development_dependency 'activesupport', '>= 4.1.0'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'coveralls', '~> 0'
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
Bumping up `activesupport` version. Specs still passing, spot checked few examples by hand and calculations seem to be accurate. Anything else worth doing/checking?