### PR TITLE
using xirr.config instead of constants

### DIFF
--- a/lib/xirr/bisection.rb
+++ b/lib/xirr/bisection.rb
@@ -11,8 +11,8 @@ module Xirr
     def xirr(midpoint, options)
 
       # Initial values
-      left  = [BigDecimal(-0.99999999, Xirr::PRECISION), cf.irr_guess].min
-      right = [BigDecimal(9.99999999, Xirr::PRECISION), cf.irr_guess + 1].max
+      left  = [BigDecimal(-0.99999999, Xirr.config.precision), cf.irr_guess].min
+      right = [BigDecimal(9.99999999, Xirr.config.precision), cf.irr_guess + 1].max
       @original_right = right
       midpoint ||= cf.irr_guess
 
@@ -29,7 +29,7 @@ module Xirr
     # @return [Boolean]
     # Checks if result is the right limit.
     def right_limit_reached?(midpoint)
-      (@original_right - midpoint).abs < Xirr::EPS
+      (@original_right - midpoint).abs < Xirr.config.eps
     end
 
     # @param left [BigDecimal]
@@ -65,13 +65,13 @@ module Xirr
           nil
         end
       else
-        midpoint.round Xirr::PRECISION
+        midpoint.round Xirr.config.precision
       end
     end
 
     def loop_rates(left, midpoint, right, iteration_limit)
       runs = 0
-      while (right - left).abs > Xirr::EPS && runs < iteration_limit do
+      while (right - left).abs > Xirr.config.eps && runs < iteration_limit do
         runs += 1
         left, midpoint, right, should_stop = bisection(left, midpoint, right)
         break if should_stop

--- a/lib/xirr/cashflow.rb
+++ b/lib/xirr/cashflow.rb
@@ -12,9 +12,9 @@ module Xirr
     #   cf << Transaction.new(-1234, date: '2013-03-31'.to_date)
     #   Or
     #   cf = Cashflow.new Transaction.new( 1000, date: '2013-01-01'.to_date), Transaction.new(-1234, date: '2013-03-31'.to_date)
-    def initialize(flow: [], period: Xirr::PERIOD, ** options)
+    def initialize(flow: [], period: Xirr.config.period, ** options)
       @period   = period
-      @fallback = options[:fallback] || Xirr::FALLBACK
+      @fallback = options[:fallback] || Xirr.config.fallback
       @options  = options
       self << flow
       self.flatten!
@@ -59,18 +59,18 @@ module Xirr
       method, options = process_options(method, options)
       if invalid?
         raise ArgumentError, invalid_message if options[:raise_exception]
-        BigDecimal(0, Xirr::PRECISION)
+        BigDecimal(0, Xirr.config.precision)
       else
         xirr = choose_(method).send :xirr, guess, options
         xirr = choose_(other_calculation_method(method)).send(:xirr, guess, options) if (xirr.nil? || xirr.nan?) && fallback
-        xirr || Xirr::REPLACE_FOR_NIL
+        xirr || Xirr.config.replace_for_nil
       end
     end
 
     def process_options(method, options)
       @temporary_period         = options[:period]
-      options[:raise_exception] ||= @options[:raise_exception] || Xirr::RAISE_EXCEPTION
-      options[:iteration_limit] ||= @options[:iteration_limit] || Xirr::ITERATION_LIMIT
+      options[:raise_exception] ||= @options[:raise_exception] || Xirr.config.raise_exception
+      options[:iteration_limit] ||= @options[:iteration_limit] || Xirr.config.iteration_limit
       return switch_fallback(method), options
     end
 
@@ -83,8 +83,8 @@ module Xirr
         @fallback = false
         method
       else
-        @fallback = Xirr::FALLBACK
-        Xirr::DEFAULT_METHOD
+        @fallback = Xirr.config.fallback
+        Xirr.config.default_method
       end
     end
 

--- a/lib/xirr/newton_method.rb
+++ b/lib/xirr/newton_method.rb
@@ -11,7 +11,7 @@ module Xirr
     # @api private
     class Function
       values = {
-          eps: Xirr::EPS,
+          eps: Xirr.config.eps,
           one:  '1.0',
           two:  '2.0',
           ten:  '10.0',
@@ -21,7 +21,7 @@ module Xirr
       # define default values
       values.each do |key, value|
         define_method key do
-          BigDecimal(value, Xirr::PRECISION)
+          BigDecimal(value, Xirr.config.precision)
         end
       end
 
@@ -36,8 +36,8 @@ module Xirr
       # Necessary for #nlsolve
       # @param x [BigDecimal]
       def values(x)
-        value = @transactions.send(@function, BigDecimal(x[0].to_s, Xirr::PRECISION))
-        [BigDecimal(value.to_s, Xirr::PRECISION)]
+        value = @transactions.send(@function, BigDecimal(x[0].to_s, Xirr.config.precision))
+        [BigDecimal(value.to_s, Xirr.config.precision)]
       end
     end
 
@@ -49,9 +49,9 @@ module Xirr
       rate = [guess || cf.irr_guess]
       begin
         nlsolve(func, rate)
-        (rate[0] <= -1 || rate[0].nan?) ? nil : rate[0].round(Xirr::PRECISION)
+        (rate[0] <= -1 || rate[0].nan?) ? nil : rate[0].round(Xirr.config.precision)
 
-          # rate[0].round(Xirr::PRECISION)
+          # rate[0].round(Xirr.config.precision)
       rescue
         nil
       end

--- a/test/test_cashflow.rb
+++ b/test/test_cashflow.rb
@@ -309,4 +309,39 @@ describe 'Cashflows' do
       assert_equal 0.112339, cf.xirr(period: 365.0)
     end
   end
+
+  describe 'with changing precision values' do
+    before(:all) do
+      # {"2021-05-17"=>-3005.69, "2021-06-03"=>-4781.38, "2021-06-17"=>3.09, "2021-06-21"=>8509.93}
+      @cf = Cashflow.new
+      @cf << Transaction.new(-117.38, date: '2021-03-17'.to_date)
+      @cf << Transaction.new(-2370.02, date: '2021-03-23'.to_date)
+      @cf << Transaction.new(0.29, date: '2021-03-26'.to_date)
+      @cf << Transaction.new(0.32, date: '2021-04-01'.to_date)
+      @cf << Transaction.new(-3005.69, date: '2021-05-17'.to_date)
+      @cf << Transaction.new(-4781.38, date: '2021-06-03'.to_date)
+      @cf << Transaction.new(3.09, date: '2021-06-17'.to_date)
+      @cf << Transaction.new(8509.93, date: '2021-06-21'.to_date)
+    end
+
+    it 'gives nil value for xirr' do
+      assert_equal 0.0, @cf.xirr
+    end
+
+    it 'gives correct value with configuration' do
+      Xirr.configure do |config|
+        config.precision = 10
+        config.eps = '1.0e-8'.to_f
+      end
+      assert_equal  -0.8317173694e0, @cf.xirr
+    end
+
+    # resetting configuration
+    after(:all) do
+      Xirr.configure do |config|
+        config.precision = 6
+        config.eps = '1.0e-6'.to_f
+      end
+    end
+  end
 end


### PR DESCRIPTION
Using `Xirr.config` to access the configurations instead of Xirr constants. 

Previously using constants we are not able to change the config using configurable. The below piece had no effect. 

```
Xirr.configure do |config|
        config.precision = 10
        config.eps = '1.0e-8'.to_f
end
```

Now the settings can be changed at the initialization to support system needs. #11 