### PR TITLE
Remove ruby inline and c function call

### DIFF
--- a/lib/xirr/base.rb
+++ b/lib/xirr/base.rb
@@ -3,7 +3,6 @@ module Xirr
   #  Base module for XIRR calculation Methods
   module Base
     extend ActiveSupport::Concern
-    require 'inline'
     attr_reader :cf
 
     # @param cf [Cashflow]
@@ -24,16 +23,8 @@ module Xirr
     # @return [BigDecimal]
     def xnpv(rate)
       cf.inject(0) do |sum, t|
-        sum + (xnpv_c rate, t.amount, periods_from_start(t.date))
+        sum + t.amount / (1+rate.to_f) ** periods_from_start(t.date)
       end
     end
-
-    inline { |builder|
-      builder.include '<math.h>'
-      builder.c '
-        double xnpv_c(double rate, double amount, double period) {
-          return amount / pow(1 + rate, period);
-        }'
-    }
   end
 end

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activesupport', '>= 4.1.0'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'coveralls', '~> 0'
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'bundler', '~> 2'
+  spec.add_development_dependency 'rake', '~> 13'
 end

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>=2.2.2'
 
   spec.add_dependency 'activesupport', '>= 4.1'
-  spec.add_dependency 'RubyInline', '~> 3'
 
   spec.add_development_dependency 'activesupport', '>= 4.1.0'
   spec.add_development_dependency 'minitest', '~> 5.11'


### PR DESCRIPTION
Use pure ruby instead of `Inline` feature. Since Ruby math functions are already implemented in C it does not impact on performance.
In C extention `BigDecmial` is casted to `double`. Ruby's `Float` internally is also implemented as `double`, so casting `BigDecimal` to `Float` in ruby has the same effect without compromising on performance 

__Benchmark:__
```
require 'date'
require 'benchmark'
require 'xirr'

def test_xirr
  cf = Xirr::Cashflow.new
  cf << Xirr::Transaction.new(-1000,  date: Date.parse('2014-01-01'))
  cf << Xirr::Transaction.new(-2000,  date: Date.parse('2014-03-01'))
  cf << Xirr::Transaction.new( 4500, date: Date.parse('2015-12-01'))
  cf.xirr
end

n = ENV.fetch('N', 1_000).to_i

module Xirr
  module Base
    def xnpv(rate)
      cf.inject(0) do |sum, t|
        sum + xnpv_impl(rate, t.amount, periods_from_start(t.date))
      end
    end
  end
end

Benchmark.bm do |x|
  x.report('Inline implementation [double]') do
    module Xirr
      module Base
        def xnpv_impl(*args)
          xnpv_c(*args)
        end
      end
    end

    n.times { test_xirr }
  end

  x.report('Ruby implementation [Float]') do
    module Xirr
      module Base
        def xnpv_impl(rate, amount, period)
          amount / (1+rate.to_f) ** period
        end
      end
    end

    n.times { test_xirr }
  end

  x.report('Ruby implementation [BigDecimal]') do
    module Xirr
      module Base
        def xnpv_impl(rate, amount, period)
          amount / (1+rate) ** period
        end
      end
    end

    n.times { test_xirr }
  end
end
```

__Benchmark result:__
```
# $ N=10000 ruby -Ilib benchmark.rb
#        user     system      total        real
# Inline implementation [double]  1.187576   0.001224   1.188800 (  1.189479)
# Ruby implementation [Float]  1.171843   0.001200   1.173043 (  1.173044)
# Ruby implementation [BigDecimal] 23.502473   0.019631  23.522104 ( 23.524580)
```
