### PR TITLE
Do not include newton module globally

### DIFF
--- a/lib/xirr/newton_method.rb
+++ b/lib/xirr/newton_method.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 require 'bigdecimal/newton'
-include Newton
 
 module Xirr
   # Class to calculate IRR using Newton Method
   class NewtonMethod
     include Base
+    include Newton
 
     # Base class for working with Newton's Method.
     # @api private

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activesupport', '>= 4.1.0'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'coveralls', '~> 0'
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'bundler', '~> 2'
+  spec.add_development_dependency 'rake', '~> 13'
 end


### PR DESCRIPTION
`Newton` module is included in global scope which is a bad practice (because every method of this module becomes global method effectively)

__Before:__
```
$ ruby -Ilib -rxirr -e "puts Object.ancestors"
Object
Newton
Jacobian
LUSolve
Kernel
BasicObject
```

__After__:
```
$ ruby -Ilib -rxirr -e "puts Object.ancestors"
Object
Kernel
BasicObject
```