### PR TITLE
update active support dependency

### DIFF
--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 10', '<= 12.3'
 
   spec.required_ruby_version = '>=2.2.2'
-  spec.add_dependency 'activesupport', '>= 4.2', '< 5.3'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_development_dependency 'minitest', '~> 5.4'
   spec.add_development_dependency 'coveralls', '~> 0'
 


### PR DESCRIPTION
Same as [PR 19](https://github.com/tubedude/xirr/pull/19) but for this branch

I've been using the no inline version of the gem with active support 6.0 and didn't encounter any issues. Calculations were ok.