### PR TITLE
fix: remove require of RubyInline

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+* Fix removal of `RubyInLine`
 ## Version 0.7.0
 * Removed `RubyInLine`
 * Removed possibility to return false from `irr_guess`

--- a/lib/xirr/base.rb
+++ b/lib/xirr/base.rb
@@ -4,7 +4,6 @@ module Xirr
   #  Base module for XIRR calculation Methods
   module Base
     extend ActiveSupport::Concern
-    require 'inline'
     attr_reader :cf
 
     # @param cf [Cashflow]


### PR DESCRIPTION
For some reason the commit added (https://github.com/tubedude/xirr/commit/0c89d72cfdb4e1e0bb448a2326adac8626dce85e) to remove RubyInline is not the same as PR #24, and a require was left in the code.

That require fails, as the dependency is no longer specified. And that makes the test to fail:

```
$ bundle exec rake test_units
/Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- inline (LoadError)
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/coder/code/xirr/lib/xirr/base.rb:7:in `<module:Base>'
	from /Users/coder/code/xirr/lib/xirr/base.rb:5:in `<module:Xirr>'
	from /Users/coder/code/xirr/lib/xirr/base.rb:3:in `<top (required)>'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/coder/code/xirr/test/test_helper.rb:12:in `<top (required)>'
	from /Users/coder/code/xirr/test/test_cashflow.rb:1:in `require_relative'
	from /Users/coder/code/xirr/test/test_cashflow.rb:1:in `<top (required)>'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `select'
	from /Users/coder/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
/Users/coder/.rbenv/versions/3.3.1/bin/bundle:25:in `load'
/Users/coder/.rbenv/versions/3.3.1/bin/bundle:25:in `<main>'
Tasks: TOP => test_units
(See full trace by running task with --trace)
```

After the change, the tests are working again.

PS: in a later PR I will be configuring Github Actions for this repo.