### PR TITLE
chore(deps): bump activesupport and ruby

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+* Allow activesupport 7. Fixes #30
+* Breaking: Require activesupport >= 6.1
+* Breaking: Require ruby >= 3.1
+
 ## Version 0.7.0
 * Removed `RubyInLine`
 * Removed possibility to return false from `irr_guess`

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>=2.2.2'
+  spec.required_ruby_version = '>=3.1'
 
-  spec.add_dependency 'activesupport', '>= 5.2', '< 7'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 8'
 
-  spec.add_development_dependency 'activesupport', '>= 5.2', '< 7'
+  spec.add_development_dependency 'activesupport', '>= 6.1', '< 8'
   spec.add_development_dependency 'minitest', '~> 5.14'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'bundler', '>= 2.2'


### PR DESCRIPTION
In this PR we allow activesupport 7 and remove support for versions 5 and 6.0 as the latter reached its EOL on June 2022. We also require Ruby 3.1, as Ruby 3.0 reached its EOL on April 23rd 2024 and Ruby 2.7 on March 31st 2023.

This fixes #30.

Using the latest version of `activesupport` for development, removed the following warnings when running the tests:

```
/Users/coder/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/activesupport-6.1.7.7/lib/active_support/xml_mini.rb:4: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of activesupport-6.1.7.7 to add base64 into its gemspec.
/Users/coder/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/activesupport-6.1.7.7/lib/active_support/notifications/fanout.rb:3: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-6.1.7.7 to add mutex_m into its gemspec.
```