### PR TITLE
Bump gem version to 7.1

### DIFF
--- a/lib/xirr/version.rb
+++ b/lib/xirr/version.rb
@@ -1,4 +1,4 @@
 module Xirr
   # Version of the Gem
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
The [version currently on rubygems.org](https://rubygems.org/gems/xirr) was published on 25 February 2024 and has dependencies `activesupport >= 5.2, < 7`.

In [a commit on 30 April 2024](https://github.com/tubedude/xirr/commit/b29d08f25570220d007fe508f24d853848a43e1a), the Ruby version and dependencies were bumped, but a new version was not yet published.

Because of this, anyone using `activesupport >= 7` will need `gem 'xirr', github: 'tubedude/xirr', branch: 'master'` in their `Gemfile` rather than `gem 'xirr'`.

This PR bumps the version, but it will require someone with rights to publish the new version. Because of that, this PR is also a request to do so 🙂